### PR TITLE
Add global experiment provider type

### DIFF
--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -667,7 +667,6 @@ def add_global_provider_type_to_experiment(experiment:dict):
             if isinstance(d,dict):
                 if "provider" in d:
                     provider = d.get("provider")
-                    print("adding!!", provider)
                     if "type" not in provider:
                         provider["type"] = updated_experiment.get("experiment-type")
                 for v in d.values():

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -5,6 +5,7 @@ import os
 import re
 from typing import List
 import uuid
+import copy
 
 from chaoslib import __version__ as chaoslib_version
 from chaoslib.control import load_global_controls
@@ -115,6 +116,8 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
     try:
         experiment = load_experiment(
             source, settings, verify_tls=not no_verify_tls)
+        if "experiment-type" in experiment:
+            experiment = add_global_provider_type_to_experiment(experiment)
     except InvalidSource as x:
         logger.error(str(x))
         logger.debug(x)
@@ -656,3 +659,23 @@ def add_activities(activities: List[Activity], pool: List[Activity],
     if not click.confirm(m):
         return
     add_activities(activities, pool)
+    
+def add_global_provider_type_to_experiment(experiment:dict):
+    updated_experiment = copy.deepcopy(experiment)
+    try:
+        def recursively_add_type(d):
+            if isinstance(d,dict):
+                if "provider" in d:
+                    provider = d.get("provider")
+                    print("adding!!", provider)
+                    if "type" not in provider:
+                        provider["type"] = updated_experiment.get("experiment-type")
+                for v in d.values():
+                    recursively_add_type(v)
+            elif isinstance(d,list):
+             for v in d:
+                 recursively_add_type(v)
+        recursively_add_type(updated_experiment)
+        return updated_experiment
+    except Exception:
+        return experiment


### PR DESCRIPTION
`experiment-type`: a global JSON experiment key to assign to all providers type key.
Add a feature that can handle the "experiment-type" key in an experiment JSON file.

usage: 
 
```JSON {
    "version": "1.0.0",
    "title": "a dummy test",
    "description": "N/A",
    "tags": [],
    "experiment-type": "python", <- this is the additional key
    "steady-state-hypothesis": {
        "title": "a steady state hypo",
        "probes": [
            {
                "type": "probe",
                "name": "all_microservices_healthy",
                "provider": {  <- no need for type key
                    "module": "chaosk8s.probes",
                    "func": "all_microservices_healthy",
                    "arguments": {
                        "ns": "default"
                    }
                },
                "tolerance": "true"
            }
        ]
    },
    "method": [
        {
            "type": "action",
            "name": "kill_microservice",
            "provider": { <- no need for type key
                "module": "chaosk8s.actions",
                "func": "kill_microservice",
                "arguments": {
                    "name": "true",
                    "ns": "default",
                    "label_selector": "N"
                }
            }
        }
    ]
}
```

Handling:
After loading the experiment JSON file, a recursive function will run all over the keys of the experiment object (to ensure all providers will be assigned no matter what object holds it).
Finding all the "provider" dictionaries and add them to the type value from the "experiment-type".
If a type already exists in the provider no assignment will occur (that you will be able to add a different type then the global).
If some exception will happen (can't see any now, but just in case), the function will return the original untouched experiment preserving the original missing type validation error.
If an unsupported provider type will be passed, the validation will return the usual error message.

## Note
This implementation probably should not be in `chaostoolkit.cli`, just a demo to show the concept.
guess somewhere in `chaostoolkit-lib` before the validation is happening.